### PR TITLE
Refactor: remove duplicate ggplot-ing code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Description: Bisplotti is primarily a plotting focused package for bisulfite and
 		  of plots that you, as a user, would like to see or have functions to 
 		  generate the plots you use on a regular basis, please consider opening
 		  either a pull request or an issue.
-Version: 0.0.8
+Version: 0.0.9
 Date: 2022-02-01
 Authors@R: c(person("Hui", "Shen", role = c("aut")),
              person("Wanding", "Zhou", role = c("aut")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,8 +8,8 @@ Description: Bisplotti is primarily a plotting focused package for bisulfite and
 		  of plots that you, as a user, would like to see or have functions to 
 		  generate the plots you use on a regular basis, please consider opening
 		  either a pull request or an issue.
-Version: 0.0.9
-Date: 2022-02-01
+Version: 0.0.10
+Date: 2022-02-02
 Authors@R: c(person("Hui", "Shen", role = c("aut")),
              person("Wanding", "Zhou", role = c("aut")),
              person("Ben", "Johnson", role = c("aut")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,8 +8,8 @@ Description: Bisplotti is primarily a plotting focused package for bisulfite and
 		  of plots that you, as a user, would like to see or have functions to 
 		  generate the plots you use on a regular basis, please consider opening
 		  either a pull request or an issue.
-Version: 0.0.7
-Date: 2022-01-28
+Version: 0.0.8
+Date: 2022-02-01
 Authors@R: c(person("Hui", "Shen", role = c("aut")),
              person("Wanding", "Zhou", role = c("aut")),
              person("Ben", "Johnson", role = c("aut")),

--- a/R/epistate.R
+++ b/R/epistate.R
@@ -285,20 +285,7 @@ plotEpiread <- function(mat, plot_read_ave = TRUE,
   
   # average methylation
   if (plot_read_ave) {
-    mat.binary <- mat # ick... copy in memory
-    mat.binary[mat.binary %in% c("M", "O")] <- 1
-    mat.binary[mat.binary %in% c("U", "S")] <- 0
-    mat.binary <- apply(mat.binary, 2, as.numeric)
-    mat.meth.ave <- data.frame(ave_meth = colMeans(mat.binary, na.rm = TRUE))
-    mat.meth.ave$position <- rownames(mat.meth.ave)
-    mat.meth.ave$y <- "Average methylation status"
-    plt_ave <- ggplot(mat.meth.ave, aes(x = position, y = y)) +
-      geom_point(aes(fill = ave_meth), size=6, pch=21, color="black") +
-      scale_fill_gradient(low = unmeth_color,
-                          high = meth_color,
-                          limits = c(0,1)) +
-      guides(color = "legend") +
-      ql_theme
+    plt_ave <- .plotAve(mat, meth_color, unmeth_color, ql_theme)
     return(list(epistate=plt,
                 meth_ave=plt_ave))
   } else {
@@ -326,4 +313,27 @@ plotEpiread <- function(mat, plot_read_ave = TRUE,
       mat.melt <- subset(mat.melt, !is.na(value)) 
   }
   return(mat.melt)
+}
+
+# helper to calculate ave methylation of a region and plot it
+.plotAve <- function(mat, meth_color, unmeth_color, theme) {
+    # check if input is a matrix
+    if (!is(mat, "matrix")) {
+      stop("Input needs to be a matrix")
+    }
+
+    mat[mat %in% c("M", "O")] <- 1
+    mat[mat %in% c("U", "S")] <- 0
+    mat <- apply(mat, 2, as.numeric)
+    mat.meth.ave <- data.frame(ave_meth = colMeans(mat, na.rm = TRUE))
+    mat.meth.ave$position <- rownames(mat.meth.ave)
+    mat.meth.ave$y <- "Average methylation status"
+    plt_ave <- ggplot(mat.meth.ave, aes(x = position, y = y)) +
+      geom_point(aes(fill = ave_meth), size=6, pch=21, color="black") +
+      scale_fill_gradient(low = unmeth_color,
+                          high = meth_color,
+                          limits = c(0,1)) +
+      guides(color = "legend") +
+      theme
+    return(plt_ave)
 }

--- a/R/epistate.R
+++ b/R/epistate.R
@@ -261,28 +261,12 @@ plotEpiread <- function(mat, plot_read_ave = TRUE,
     ql_theme <- ql_theme + theme(axis.text.x = element_blank(),
                                  axis.ticks.x = element_blank())
   }
-  
-  # auto-detect input type
-  is.cg = FALSE
-  is.gc = FALSE
-  if(any(mat %in% c("M", "U"))) is.cg = TRUE
-  if(any(mat %in% c("S", "O"))) is.gc = TRUE
-  
-  # break if both are FALSE
-  if (isFALSE(is.cg) & isFALSE(is.gc)) {
-    message("Don't know what to do with input.")
-    stop("Please run tabulateEpibed() first to produce input for this function.")
-  }
-  
-  # cast to a 'melted' data frame
-  mat.melt <- reshape2::melt(mat, id.vars = rownames(mat))
-  if (!show_filtered) {
-      mat.melt <- subset(mat.melt, !is.na(value)) 
-  }
+
+  mat.melt <- .makePlotData(mat, show_filtered)
   
   snp_list <- c("A", "T", "G", "C")
-  # plot
 
+  # plot
   plt <- ggplot(mat.melt, aes(x = Var2, y = Var1)) +
       geom_label(
           data = subset(mat.melt, value %ni% c("M", "U", "O", "S")),
@@ -322,3 +306,24 @@ plotEpiread <- function(mat, plot_read_ave = TRUE,
   }
 }
 
+# helper to make the melted dataset for plotting
+.makePlotData <- function(mat, show_filtered) {
+  # auto-detect input type
+  is.cg = FALSE
+  is.gc = FALSE
+  if(any(mat %in% c("M", "U"))) is.cg = TRUE
+  if(any(mat %in% c("S", "O"))) is.gc = TRUE
+  
+  # break if both are FALSE
+  if (isFALSE(is.cg) & isFALSE(is.gc)) {
+    message("Don't know what to do with input.")
+    stop("Please run tabulateEpibed() first to produce input for this function.")
+  }
+  
+  # cast to a 'melted' data frame
+  mat.melt <- reshape2::melt(mat, id.vars = rownames(mat))
+  if (!show_filtered) {
+      mat.melt <- subset(mat.melt, !is.na(value)) 
+  }
+  return(mat.melt)
+}

--- a/R/epistate.R
+++ b/R/epistate.R
@@ -283,39 +283,21 @@ plotEpiread <- function(mat, plot_read_ave = TRUE,
   snp_list <- c("A", "T", "G", "C")
   # plot
 
-  if (is.cg) {
-    plt <- ggplot(mat.melt, aes(x = Var2, y = Var1)) +
-        geom_label(
-            data = subset(mat.melt, value %ni% c("M", "U")),
-            aes(label = value)
-        ) +
-        geom_point(
-            data = subset(mat.melt, value %ni% snp_list),
-            aes(fill = value), size = 6, pch = 21, color = "black"
-        ) +
-        scale_fill_manual(
-            values = c(M = meth_color, U = unmeth_color),
-            na.value = na_color
-        ) +
-        guides(color = "legend") +
-        ql_theme
-  } else {
-    plt <- ggplot(mat.melt, aes(x = Var2, y = Var1)) +
-        geom_label(
-            data = subset(mat.melt, value %ni% c("S","O")),
-            aes(label = value)
-        ) +
-        geom_point(
-            data = subset(mat.melt, value %ni% snp_list),
-            aes(fill = value), size = 6, pch = 21, color = "black"
-        ) +
-        scale_fill_manual(values = c(O=meth_color,
-                                    S=unmeth_color),
-                        na.value = na_color) +
+  plt <- ggplot(mat.melt, aes(x = Var2, y = Var1)) +
+      geom_label(
+          data = subset(mat.melt, value %ni% c("M", "U", "O", "S")),
+          aes(label = value)
+      ) +
+      geom_point(
+          data = subset(mat.melt, value %ni% snp_list),
+          aes(fill = value), size = 6, pch = 21, color = "black"
+      ) +
+      scale_fill_manual(
+          values = c(meth_color, unmeth_color),
+          na.value = na_color
+      ) +
       guides(color = "legend") +
       ql_theme
-      
-  }
   
   # average methylation
   if (plot_read_ave) {


### PR DESCRIPTION
There wasn't much different between the CG and GC table plotting sections. Diff between the duplicate code chunks: 

```diff
diff --git a/cg.r b/gc.r
index 6208192..f7a7432 100644
--- a/cg.r
+++ b/gc.r
@@ -4,11 +4,11 @@ plt <- ggplot(mat.melt, aes(x = Var2, y = Var1)) +
         aes(fill = value), size = 6, pch = 21, color = "black"
     ) +
     geom_label(
-        data = subset(mat.melt, value %ni% c("M", "U")),
+        data = subset(mat.melt, value %ni% c("S","O")),
         aes(label = value)
     ) +
     scale_fill_manual(
-        values = c(M = meth_color, U = unmeth_color),
+        values = c(O = meth_color, S = unmeth_color),
     na.value = na_color) 
     + guides(color = "legend") 
     + ql_theme

```

Collapsing makes it easier to make plotting changes and not have to change the same
code twice. This refactor works without too much more work since M, U
and O, S fit alphabetically into the meth_color, unmeth_color scale.

The helper `.makePlotData` will give more flexibility to the epistate calling function to make plots without having to call `plotEpiread`